### PR TITLE
Include FmcApi as a requirement!  Drop the hard version requirement on packages with common conflicts.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ pip-upgrade-outdated==1.5
 pylint==2.2.2
 requests==2.21.0
 six==1.12.0
-style==1.1.5
+style
 typed-ast==1.3.2
 update==0.0.1
-urllib3==1.26.5
+urllib3
 virtualenv==16.4.0
 wrapt==1.11.1
+fmcapi


### PR DESCRIPTION
Seeing as FmcApi is an actual requirement, make sure it is listed/installed.

Could probably make all the packages use an identified range (or at least just use the current hard-equals as a greater-equal to allow for future versions, because in my testing the newest version of each of these packages worked with FMC 7.3.1)